### PR TITLE
Using buffer dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const Buffer = require('buffer').Buffer
+
 module.exports = codecs
 
 codecs.ascii = createString('ascii')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.1.0",
   "description": "Create an binary encoder/decoder for json, utf-8 or custom types",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^5.6.0"
+  },
   "devDependencies": {
     "standard": "^12.0.1",
     "tape": "^4.10.1"


### PR DESCRIPTION
To removed the dependency on node globals this PR replaces the dependency on Buffer to use the npm `buffer` package.