### PR TITLE
Asserting that the decoded binary is a Buffer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ codecs.binary = {
         : Buffer.from(obj.buffer, obj.byteOffset, obj.byteLength)
   },
   decode: function decodeBinary (buf) {
-    return buf
+    return Buffer.isBuffer(buf)
+      ? buf
+      : Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength)
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -28,9 +28,15 @@ tape('hex', function (t) {
 tape('binary', function (t) {
   var enc = codecs()
   t.same(enc.name, 'binary')
-  t.same(enc.encode('hello world'), Buffer.from('hello world'))
-  t.same(enc.encode(Buffer.from('hello world')), Buffer.from('hello world'))
-  t.same(enc.decode(Buffer.from('hello world')), Buffer.from('hello world'))
+  const input = Buffer.from('hello world')
+  t.same(enc.encode('hello world'), input)
+  t.equals(enc.encode(input), input)
+  t.equals(enc.decode(input), input)
+  const uint8 = new Uint8Array(input.buffer, input.byteOffset, input.byteLength)
+  t.ok(Buffer.isBuffer(enc.encode(uint8)))
+  t.equals(enc.encode(uint8).compare(input), 0)
+  t.ok(Buffer.isBuffer(enc.decode(uint8)))
+  t.equals(enc.decode(uint8).compare(input), 0)
   t.end()
 })
 


### PR DESCRIPTION
All codecs except `binary` are returning `Buffer` instances on `decode` but `binary` may return the input which can be a `Uint8Array` in some protocols. This PR prevents odd errors that may occur if the input is a Uint8Array.