### PR TITLE
Allow custom fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ console.log(json.decode(new Buffer('{"hello":"world"}'))) // {hello: 'world'}
 
 ## API
 
-#### `var codec = codecs(type)`
+#### `var codec = codecs(type, [fallback])`
 
 Create a new codec.
 
@@ -41,7 +41,7 @@ Supported types are
 * utf-16le
 * binary
 
-If an unknown type is passed in `binary` is used.
+If an unknown type is passed-in, the `fallback` is used if given, else `binary`.
 If you want to use a custom codec you can pass in an object containing a an `encode` and `decode` method and that will be returned.
 
 #### `var buf = codec.encode(value)`

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ codecs.binary = {
   }
 }
 
-function codecs (fmt) {
+function codecs (fmt, fallback) {
   if (typeof fmt === 'object' && fmt && fmt.encode && fmt.decode) return fmt
 
   switch (fmt) {
@@ -39,7 +39,7 @@ function codecs (fmt) {
     case 'utf16le': return codecs.utf16le
   }
 
-  return codecs.binary
+  return fallback !== undefined ? fallback : codecs.binary
 }
 
 function createJSON (newline) {

--- a/test.js
+++ b/test.js
@@ -59,3 +59,10 @@ tape('uint8arrays in binary', function (t) {
   t.same(buf, Buffer.from([1, 2, 3]))
   t.end()
 })
+
+tape('custom fallback', function (t) {
+  t.equals(codecs('baseless', null), null)
+  const custom = { decode: function () {}, encode: function () {} }
+  t.equals(codecs('baseless', custom), custom)
+  t.end()
+})


### PR DESCRIPTION
For a project I use I want to have a different default than `binary`. In the current setup its unclear if `codecs(userCodec)` returns `binary` because it's input was `binary` or because that codec was or isn't supported. With the change in this PR I could either specify my preferred codec or `null` which I then could use to throw an error message or do something different.